### PR TITLE
Headless mode by default, fix tab-picking, add login.py

### DIFF
--- a/browser_session.py
+++ b/browser_session.py
@@ -29,13 +29,13 @@ BROWSER_ARGS = [
 
 IGNORE_ARGS = ["--enable-automation"]
 
-# Twitter blocks headless browsers. Use Xvfb virtual display instead.
-# Install: apt-get install -y xvfb
-# Start: Xvfb :99 -screen 0 1280x720x24 & export DISPLAY=:99
-USE_HEADLESS = False  # Set True only if Xvfb is NOT available
+# Verified 2026-05-07: with the existing anti-detection args + a logged-in profile,
+# X serves search/user/feed/etc. fine in true Playwright headless mode. Keep headless
+# on for tool calls; interactive flows (login) override via the headless= kwarg.
+USE_HEADLESS = True
 
 
-async def get_persistent_context() -> tuple:
+async def get_persistent_context(headless: bool | None = None) -> tuple:
     """Launch browser with persistent context.
 
     Returns (playwright, context) — caller must close both when done.
@@ -43,6 +43,8 @@ async def get_persistent_context() -> tuple:
     The persistent context stores cookies in PROFILE_DIR, which persists
     between launches. This is how real browsers work — cookies survive
     because the profile directory keeps them.
+
+    Pass headless=False to force a visible window (used by login.py).
     """
     os.makedirs(PROFILE_DIR, exist_ok=True)
 
@@ -53,10 +55,8 @@ async def get_persistent_context() -> tuple:
     storage_path = Path(STORAGE_BACKUP)
     profile_cookies = Path(PROFILE_DIR) / "Default" / "Cookies"
 
-    # Check if Xvfb is running — if so, use non-headless (avoids Twitter bot detection)
-    import shutil
-    has_display = os.environ.get("DISPLAY") is not None
-    headless = USE_HEADLESS if has_display else True  # Fallback to headless if no display
+    if headless is None:
+        headless = USE_HEADLESS
 
     context = await pw.chromium.launch_persistent_context(
         user_data_dir=PROFILE_DIR,
@@ -79,6 +79,32 @@ async def get_persistent_context() -> tuple:
             pass  # Non-critical
 
     return pw, context
+
+
+async def get_fresh_page(context: BrowserContext):
+    """Open a new tab in the persistent context and focus it.
+
+    Avoids reusing tabs restored by --restore-last-session, which would otherwise
+    leave operations running on whichever stale tab happened to be at index 0.
+    """
+    page = await context.new_page()
+    try:
+        await page.bring_to_front()
+    except Exception:
+        pass
+    return page
+
+
+async def close_stale_pages(context: BrowserContext, keep: object) -> None:
+    """Close every page in the context except `keep`. Use for interactive flows
+    where restored tabs would clutter the window."""
+    for p in list(context.pages):
+        if p is keep:
+            continue
+        try:
+            await p.close()
+        except Exception:
+            pass
 
 
 async def save_session(context: BrowserContext):
@@ -115,7 +141,7 @@ async def import_fresh_cookies(cookies_path: str):
             await context.add_cookies(state["cookies"])
 
         # Visit Twitter to activate cookies and let them refresh
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
         await page.goto("https://x.com/home", wait_until="domcontentloaded")
         await page.wait_for_timeout(5000)
 

--- a/login.py
+++ b/login.py
@@ -1,0 +1,54 @@
+"""Interactive login helper for the persistent Chrome profile.
+
+Run this once, log in to X manually in the browser window that opens,
+then press Enter in the terminal. Cookies persist for all future MCP calls.
+"""
+
+import asyncio
+import sys
+from browser_session import get_persistent_context, save_session, get_fresh_page, close_stale_pages
+
+
+async def interactive_login():
+    pw, context = await get_persistent_context(headless=False)
+
+    page = await get_fresh_page(context)
+    await close_stale_pages(context, keep=page)
+    await page.goto("https://x.com/i/flow/login", wait_until="domcontentloaded")
+
+    print("\n" + "=" * 60)
+    print("  Browser opened. Log in to X with your burner account.")
+    print("  When you see the home timeline, return here and press Enter.")
+    print("=" * 60 + "\n")
+
+    try:
+        input("Press Enter after you have finished logging in... ")
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted, closing without saving.")
+        await context.close()
+        await pw.stop()
+        return 1
+
+    cookies = await context.cookies("https://x.com")
+    cookie_names = {c["name"] for c in cookies}
+
+    if "auth_token" not in cookie_names:
+        print("\nWARNING: 'auth_token' cookie not found — login may have failed.")
+        print(f"Cookies present: {sorted(cookie_names)}")
+        print("Closing without overwriting backup.")
+        await context.close()
+        await pw.stop()
+        return 2
+
+    await save_session(context)
+    await context.close()
+    await pw.stop()
+
+    print("\nLogin saved. auth_token + ct0 captured.")
+    print("Profile: ~/.twitter-mcp/chrome-profile/")
+    print("Backup:  ~/.twitter-mcp/storage_state.json")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(interactive_login()))

--- a/tools_feed.py
+++ b/tools_feed.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import concurrent.futures
-from browser_session import get_persistent_context, close_session
+from browser_session import get_persistent_context, close_session, get_fresh_page
 
 
 async def read_feed(max_results: int = 20) -> str:
@@ -9,7 +9,7 @@ async def read_feed(max_results: int = 20) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         # Use domcontentloaded instead of networkidle (Twitter never stops loading)
         await page.goto("https://x.com/home", wait_until="domcontentloaded", timeout=20000)
@@ -65,7 +65,7 @@ async def read_notifications() -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         await page.goto("https://x.com/notifications", wait_until="domcontentloaded", timeout=20000)
         await page.wait_for_selector('[data-testid="cellInnerDiv"]', timeout=15000)
@@ -115,7 +115,7 @@ async def read_bookmarks(max_results: int = 20) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         await page.goto("https://x.com/i/bookmarks", wait_until="domcontentloaded", timeout=20000)
         await page.wait_for_selector('[data-testid="tweet"]', timeout=15000)

--- a/tools_read.py
+++ b/tools_read.py
@@ -3,7 +3,7 @@ import urllib.parse
 from playwright.async_api import async_playwright
 import concurrent.futures
 from typing import Optional
-from browser_session import get_persistent_context, close_session
+from browser_session import get_persistent_context, close_session, get_fresh_page
 
 
 async def _search_tweets_async(query: str, max_results: int = 10) -> str:
@@ -11,7 +11,7 @@ async def _search_tweets_async(query: str, max_results: int = 10) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         # Navigate to search results
         encoded_query = urllib.parse.quote(query)
@@ -88,7 +88,7 @@ async def _get_user_profile_async(username: str) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         # Navigate to user profile
         url = f"https://x.com/{username}"
@@ -137,7 +137,7 @@ async def _get_user_tweets_async(username: str, max_results: int = 10) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         # Navigate to user profile
         url = f"https://x.com/{username}"
@@ -226,7 +226,7 @@ async def _get_trending_async() -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         # Navigate to home page — trending sidebar loads here
         await page.goto("https://x.com/home", wait_until="networkidle")

--- a/tools_write.py
+++ b/tools_write.py
@@ -1,7 +1,7 @@
 import asyncio
 import json
 import concurrent.futures
-from browser_session import get_persistent_context, close_session
+from browser_session import get_persistent_context, close_session, get_fresh_page
 
 
 async def _wait_for_load(page):
@@ -15,7 +15,7 @@ async def post_tweet(text: str) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         await page.goto("https://x.com/compose/post")
         await _wait_for_load(page)
@@ -39,7 +39,7 @@ async def reply_to_tweet(tweet_url: str, text: str) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         await page.goto(tweet_url)
         await _wait_for_load(page)
@@ -68,7 +68,7 @@ async def like_tweet(tweet_url: str) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         await page.goto(tweet_url)
         await _wait_for_load(page)
@@ -88,7 +88,7 @@ async def retweet(tweet_url: str) -> str:
     pw, context = await get_persistent_context()
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
 
         await page.goto(tweet_url)
         await _wait_for_load(page)

--- a/twitter_keepalive.py
+++ b/twitter_keepalive.py
@@ -10,7 +10,7 @@ import json
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from browser_session import get_persistent_context, close_session
+from browser_session import get_persistent_context, close_session, get_fresh_page
 
 LOG_DIR = Path(__file__).parent / "data"
 
@@ -22,7 +22,7 @@ async def ping_twitter() -> dict:
         return {"success": False, "error": f"Browser launch failed: {e}"}
 
     try:
-        page = context.pages[0] if context.pages else await context.new_page()
+        page = await get_fresh_page(context)
         resp = await page.goto("https://x.com/home", wait_until="domcontentloaded", timeout=20000)
         url = page.url
         status = resp.status if resp else 0


### PR DESCRIPTION
## Summary
- **Run headless by default.** With the existing anti-detection args + a logged-in profile, X serves search/user/feed fine in true Playwright headless mode — verified locally on a fresh login. Headful + Xvfb is no longer required for ordinary tool calls.
- **Fix tab-picking bug.** Every tool was reusing `context.pages[0]`, but `--restore-last-session` (in `BROWSER_ARGS`) means index 0 can be any restored tab from a prior session, not a clean Twitter tab. Operations were occasionally navigating the wrong tab. New `get_fresh_page()` helper opens a new tab + brings it to front; all 13 call sites swapped over.
- **Add `login.py`.** README line 74 currently says `python3 -c "from browser_session import login; login()"`, but `login` has never been defined in `browser_session.py` (verified across full git history — no `def login` anywhere). `login.py` fills the gap: opens the persistent profile headful, navigates to `x.com/i/flow/login`, closes restored tabs, waits for the user to log in and press Enter, verifies the `auth_token` cookie before saving.
- Add `headless=` kwarg on `get_persistent_context()` so `login.py` can force a visible window without changing the global default.
- Add `close_stale_pages()` helper for interactive flows that want a clean window.

## Why
Without these, on a typical desktop:
1. Every tool call popped a Chromium window (since `USE_HEADLESS = False`)
2. Restored tabs from a prior session would hijack the operation's `pages[0]`
3. There was no working way to perform the initial login despite the README claiming there was

## Test plan
- [x] `python3 login.py` opens a single visible Chromium tab on `x.com/i/flow/login`, restored tabs are closed, and after manual login the `auth_token` cookie is detected and saved.
- [x] `twitter_search`, `twitter_user`, `twitter_user_tweets`, `twitter_feed` all return real data after login.
- [x] No Chromium window is shown during tool calls — verified `--headless` flag in the running chromium process.
- [x] Verified across full `git log --all` that `def login` has never existed in this repo.

Note: I left the `twitter_trending` `wait_until="networkidle"` bug alone — it's a separate concern (`x.com/home` rarely goes idle due to background polling), happy to send a follow-up PR if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)